### PR TITLE
patching CI/CD bug due to setuptools

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install ChemML and dependencies
       shell: bash -l {0}
       run: |
-        pip install --upgrade pip setuptools<=81.0.0 wheel
+        pip install --upgrade pip 'setuptools<=81.0.0' wheel
         pip install -e . --use-pep517
         pip install pytest pytest-cov
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install ChemML and dependencies
       shell: bash -l {0}
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip setuptools<=81.0.0 wheel
         pip install -e . --use-pep517
         pip install pytest pytest-cov
 


### PR DESCRIPTION
setuptools v81 is now set as default, as updates have removed pkg-resources from setuptools, which breaks code.